### PR TITLE
Replace all HTTP URI with their HTTPS counterpart where possible

### DIFF
--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -13,16 +13,16 @@
     <link href="/assets/css/main.css" rel="stylesheet">
     <!-- Custom Fonts -->
     <link href="/assets/fonts/font-awesome-4.4.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link rel="shortcut icon" type="image/png" href="/assets/img/favicon.png"/>
 
     <meta property="og:title" content="opensanca | meetup sancarlense " />
     <meta property="og:type" content="tecnologia, opensource, desenvolvimento, pizza, café e beer code!" />
     <meta property="og:site_name" content="opensanca" />
-    <meta property="og:url" content="http://www.opensanca.com.br/" />
-    <meta property="og:image" content="http://www.opensanca.com.br/img/boy-macro.jpg" />
-    <meta property="og:image" content="http://www.opensanca.com.br/img/logo-opensanca.png" />
+    <meta property="og:url" content="https://www.opensanca.com.br/" />
+    <meta property="og:image" content="https://www.opensanca.com.br/img/boy-macro.jpg" />
+    <meta property="og:image" content="https://www.opensanca.com.br/img/logo-opensanca.png" />
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -56,7 +56,7 @@
                         <a class="page-scroll" href="#about">Sobre</a>
                     </li>
                     <li>
-                        <a href="http://www.meetup.com/opensanca/" target="_blank">Eventos</a>
+                        <a href="https://www.meetup.com/opensanca/" target="_blank">Eventos</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="https://github.com/opensanca" target="_blank">Projetos</a>
@@ -97,7 +97,7 @@
             <div class="col-lg-12">
                 <h2>Sobre</h2>
                 <p>
-                  Olá, antes de tudo, agradecemos pela sua visita aqui  no <a href="http://www.meetup.com/pt-BR/opensanca" target="_blank">OpenSanca</a>
+                  Olá, antes de tudo, agradecemos pela sua visita aqui  no <a href="https://www.meetup.com/pt-BR/opensanca" target="_blank">OpenSanca</a>
                   o objetivo nosso é trazer a cultura dos meetup e realizar
                   reuniões e workshop periodicamente no interior paulista (São Carlos, Araraquara, Matão, Ibaté), buscamos trazer a tona discussão sobre
                   tecnologias Open Source, e esperamos que esses encontros sejam além de tecnologias, esperamos que ele forneça apoio em diversos
@@ -111,16 +111,15 @@
 
                 Queremos fazer um bate papo no qual todos possam colaborar e  fomentar um networking com empresas, desenvolvedores, comunidades acadêmicas. <br><br>
 
-                Faça parte do <a href="http://www.meetup.com/pt-BR/opensanca/" target="_blank">OpenSanca</a> ele é livre e sempre será, traga seus amigos,
+                Faça parte do <a href="https://www.meetup.com/pt-BR/opensanca/" target="_blank">OpenSanca</a> ele é livre e sempre será, traga seus amigos,
                 independente da carreira que segue, aqui oferecemos workshops, palestras, churrasco, e tudo aquilo que acharmos que é bacana para você! Entre, agora!
                 </p>
             </div>
         </div>
         <div class="row">
           <div class="col-md-4">
-                 
                   <a href="https://slack-opensanca.herokuapp.com/"><i class="fa fa-slack fa-5x"></i></a>
-                  <h3>Slack <img src="http://slack-opensanca.herokuapp.com/badge.svg"></h3>
+                  <h3>Slack <img src="https://slack-opensanca.herokuapp.com/badge.svg"></h3>
                   <p>
                     Tá afim de conversar com uma galera "hibrída" que não importa a linguagem, seja Java, Ruby, Python, Swift, não acredita que tem tudo isso misturado?
                     Crie seu networking, agora mesmo! Tem dúvidas sobre alguma lib ou tecnologia? <br> <br>
@@ -142,14 +141,14 @@
           </div>
 
           <div class="col-md-4">
-            <a href="https:/twiter.com/opensanca" target="_blank">
+            <a href="https://www.meetup.com/pt-BR/opensanca" target="_blank">
               <i class="fa fa-star fa-5x"></i>  </a>
               <h3>Meetup</h3>
               <p>
                Ficou interessado nos workshops e palestras, como você vai fazer para participar?
                Entre no nosso canal do meetup, que você irá receber um e-mail nosso de cada evento que criarmos,
                já estamos com programação agendada até junho. <br> <br>
-               <a href="http://www.meetup.com/pt-BR/opensanca/" target="_blank" class="btn btn-default btn-lg">Cola Aêêêê!</a>
+               <a href="https://www.meetup.com/pt-BR/opensanca/" target="_blank" class="btn btn-default btn-lg">Cola Aêêêê!</a>
               </p>
           </div>
 
@@ -231,7 +230,7 @@
         <div class="row">
 
         <div class="col-md-4 col-centered partner-logo">
-            <a href="http://monitoratec.com.br/" title="Ir para Monitora" target="_blank">
+            <a href="https://monitoratec.com.br/" title="Ir para Monitora" target="_blank">
               <figure>
                   <img src="/assets/img/logo-monitora.png" title="Monitora" alt="Logo Monitora"/>
                   <figcaption>Empresa localizada em São Carlos, com mais de 60 colaboradores, todos focados em encontrar soluções para a sua empresa. Nosso desafio é criar, inovar e atender!</figcaption>
@@ -240,7 +239,7 @@
         </div>
 
         <div class="col-md-4 col-centered partner-logo">
-            <a href="http://www.s2it.com.br" title="Ir para S2it" target="_blank">
+            <a href="https://www.s2it.com.br" title="Ir para S2it" target="_blank">
               <figure>
                   <img src="/assets/img/logo-s2it.png" title="S2it" alt="Logo S2it"/>
                   <figcaption>Somos uma empresa formada por mais de duzentas pessoas inquietas e comprometidas, incessantes na busca pela inovação e tecnologia.</figcaption>
@@ -468,7 +467,7 @@
 <script src="/assets/js/custom.js"></script>
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-98998566-2"></script>
-<script async defer src="http://slack-opensanca.herokuapp.com/slackin.js"></script>
+<script async defer src="https://slack-opensanca.herokuapp.com/slackin.js"></script>
 <script>
     $( document ).ready(function() {
       let today = new Date();


### PR DESCRIPTION
This is necessary so the browser doesn't complain about security issues while browsing the website using any of the https://* supported domains.

The only link that is still using HTTP is http://ft.ventures, the reason being that https://ft.ventures does not work properly yet.

Fixes #27